### PR TITLE
특정 태그를 포함하고 있는 사진 리스트 가져오기

### DIFF
--- a/src/graphql/Photo/dataSources.js
+++ b/src/graphql/Photo/dataSources.js
@@ -15,6 +15,10 @@ class dataSources extends MongoDataSource {
       .sample(1);
   }
 
+  getPhotos(query) {
+    return this.findByFields(query);
+  }
+
   createPhoto(photo) {
     return this.model.create(photo);
   }

--- a/src/graphql/Photo/queries.js
+++ b/src/graphql/Photo/queries.js
@@ -2,6 +2,8 @@ const queries = `
   randomPhoto(id: ID): Photo
 
   photo(id: ID): Photo
+
+  photos(tag: String!): [Photo]
 `;
 
 module.exports = { queries };

--- a/src/graphql/Photo/resolvers.js
+++ b/src/graphql/Photo/resolvers.js
@@ -16,6 +16,13 @@ const queries = {
 
     return result;
   },
+
+  photos: async (_, { tag }, { dataSources: { photos } }) => {
+    const searchTag = tag.includes("#") ? tag : `#${tag}`;
+    const result = await photos.getPhotos({ tags: searchTag });
+
+    return result;
+  },
 };
 
 const mutations = {


### PR DESCRIPTION
## Task 📄

- [[Query] 특정 태그를 포함하고 있는 사진 리스트 가져오기 (GraphQL)](https://www.notion.so/Query-GraphQL-a82d7cd1baae46c89ed44248d8a2a464)

## Description 💬

- tag 문자 검색 전 전처리
- 태그 포함 사진 리스트 DB에 조회

## Point 🔑

- array that contains a specific value
